### PR TITLE
Fixes Feature scroll chat to bottom down arrow

### DIFF
--- a/components/Chat/index.vue
+++ b/components/Chat/index.vue
@@ -187,6 +187,7 @@
               small
               light
               color="yellow"
+              @click="scrollToBottom(true)"
             ><v-icon>keyboard_arrow_down</v-icon>
             </v-btn>
           </v-flex>


### PR DESCRIPTION
Adds the on click handler back to the down arrow to enable scroll chat to bottom.

Tested and works on my machine.